### PR TITLE
Fix for off-by-one error that causes /equipoh to not work with nampower sometimes

### DIFF
--- a/NampowerAPI.lua
+++ b/NampowerAPI.lua
@@ -1672,7 +1672,7 @@ function API.IsItemInSlot(itemIdOrName, inventorySlot)
 
     -- Use native v2.18 GetEquippedItem if available
     if GetEquippedItem then
-        local slotInfo = GetEquippedItem("player", inventorySlot - 1)  -- 0-indexed
+        local slotInfo = GetEquippedItem("player", inventorySlot)
         if slotInfo and slotInfo.itemId then
             local checkId = tonumber(itemIdOrName)
             if checkId then


### PR DESCRIPTION
With nampower installed, /equipoh doesn't work if the offhand you are equipping has the same name as your equipped mainhand weapon, because there is an off-by-one error in the code. The code checks your main hand slot (16) instead your offhand (17) and doesn't equip the offhand because it thinks it's already equipped in the offhand slot (it's checking the wrong slot). This simple PR fixes that bug.