### PR TITLE
add support for 'button' conditional

### DIFF
--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -5422,9 +5422,28 @@ end
 
 -- A list of Conditionals and their functions to validate them
 CleveRoids.Keywords = {
+    -- [button:N] — true while mouse button N is held (1=Left, 2=Right, 3=Middle,
+    -- 4/5=extra). Routed through Multi so OR/AND lists and repeated groups behave
+    -- like every other argument conditional ([button:1/2] = left or right).
+    -- [button] with no argument — true if any mapped mouse button is held.
     button = function(conditionals)
-        local button = conditionals._groups.button[1].values[1]
-        return CleveRoids.buttons[button] and IsMouseButtonDown(CleveRoids.buttons[button])
+        if type(conditionals.button) ~= "table" then
+            return CleveRoids.AnyMouseButtonDown()
+        end
+        return Multi(conditionals.button, function(button)
+            local name = CleveRoids.buttons[button]
+            return name and IsMouseButtonDown(name) or false
+        end, conditionals, "button")
+    end,
+
+    nobutton = function(conditionals)
+        if type(conditionals.nobutton) ~= "table" then
+            return not CleveRoids.AnyMouseButtonDown()
+        end
+        return NegatedMulti(conditionals.nobutton, function(button)
+            local name = CleveRoids.buttons[button]
+            return not (name and IsMouseButtonDown(name))
+        end, conditionals, "nobutton")
     end,
 
     exists = function(conditionals)
@@ -9335,6 +9354,7 @@ CleveRoids.STATIC_CONDITIONALS = {
     inbag = true, noinbag = true,
     mod = true, nomod = true,
     keydown = true, nokeydown = true,
+    button = true, nobutton = true,
     swimming = true, noswimming = true, swim = true, noswim = true,
     indoors = true, noindoors = true, outdoors = true, nooutdoors = true,
     rooted = true, norooted = true,

--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -5422,6 +5422,11 @@ end
 
 -- A list of Conditionals and their functions to validate them
 CleveRoids.Keywords = {
+    button = function(conditionals)
+        local button = conditionals._groups.button[1].values[1]
+        return CleveRoids.buttons[button] and IsMouseButtonDown(CleveRoids.buttons[button])
+    end,
+
     exists = function(conditionals)
         return UnitExists(conditionals.target)
     end,

--- a/Utility.lua
+++ b/Utility.lua
@@ -664,6 +664,16 @@ CleveRoids.buttons = {
     ['5'] = 'Button5',
 }
 
+-- True while any mapped mouse button is held. Backs the argument-less [button] /
+-- [nobutton], mirroring how a bare [mod] means "any modifier". Bare [nobutton] is
+-- the practical "activated by a keybind, not a click" test.
+function CleveRoids.AnyMouseButtonDown()
+    for _, name in pairs(CleveRoids.buttons) do
+        if IsMouseButtonDown(name) then return true end
+    end
+    return false
+end
+
 CleveRoids.kmods = {
     ctrl   = IsControlKeyDown,
     lctrl  = IsLeftControlKeyDown,

--- a/Utility.lua
+++ b/Utility.lua
@@ -656,6 +656,14 @@ function CleveRoids.PrintT(t, depth)
     end
 end
 
+CleveRoids.buttons = {
+    ['1'] = 'LeftButton',
+    ['2'] = 'RightButton',
+    ['3'] = 'MiddleButton',
+    ['4'] = 'Button4',
+    ['5'] = 'Button5',
+}
+
 CleveRoids.kmods = {
     ctrl   = IsControlKeyDown,
     lctrl  = IsLeftControlKeyDown,


### PR DESCRIPTION
**command:** button:number.
**description:**  used to check with which mouse button you activated the macro. [button:1] is the default, left button, [button:2] right, [button:3] middle and  extra buttons [button:4],  [button:5].
**example:** `/cast [button:1]Banish (Rank 1);Banish (Rank 2)`
